### PR TITLE
Enhance rate limiting

### DIFF
--- a/rate/http/visit_context.go
+++ b/rate/http/visit_context.go
@@ -6,25 +6,59 @@ import (
 	"github.com/Conflux-Chain/go-conflux-util/http/middlewares"
 )
 
+const (
+	CtxKeyVisitResource middlewares.CtxKey = "X-Visit-Resource"
+)
+
+// VisitContext encapsulates remote info such as IP, API key etc., from HTTP request context,
+// or you can wrap any custom field within the context chain.
 type VisitContext struct {
-	Resource string // e.g. http requests, RPC requests
-	IP       string // real remote adddress
-	ApiKey   string // optional api key
+	ctx context.Context
 }
 
-// ParseVisitContext parses visit context from HTTP request context.
-func ParseVisitContext(ctx context.Context, resource string) VisitContext {
-	visit := VisitContext{
-		Resource: resource,
+func NewVisitContext(ctx context.Context, resource string) VisitContext {
+	return VisitContext{
+		ctx: context.WithValue(ctx, CtxKeyVisitResource, resource),
 	}
+}
 
-	if ip, ok := middlewares.GetRealIPFromContext(ctx); ok {
-		visit.IP = ip
+func (vc VisitContext) Context() context.Context {
+	return vc.ctx
+}
+
+func (vc VisitContext) WithValue(k, v interface{}) VisitContext {
+	return VisitContext{
+		ctx: context.WithValue(vc.ctx, k, v),
 	}
+}
 
-	if apiKey, ok := middlewares.GetApiKeyFromContext(ctx); ok {
-		visit.ApiKey = apiKey
-	}
+func (vc VisitContext) Value(k interface{}) interface{} {
+	return vc.ctx.Value(k)
+}
 
-	return visit
+func (vc VisitContext) Resource() (string, bool) {
+	resource, ok := vc.Value(CtxKeyVisitResource).(string)
+	return resource, ok
+}
+
+func (vc VisitContext) WithResource(resource string) VisitContext {
+	return vc.WithValue(CtxKeyVisitResource, resource)
+}
+
+func (vc VisitContext) Ip() (string, bool) {
+	resource, ok := vc.Value(middlewares.CtxKeyRealIP).(string)
+	return resource, ok
+}
+
+func (vc VisitContext) WithIp(resource string) VisitContext {
+	return vc.WithValue(middlewares.CtxKeyRealIP, resource)
+}
+
+func (vc VisitContext) ApiKey() (string, bool) {
+	resource, ok := vc.Value(middlewares.CtxKeyApiKey).(string)
+	return resource, ok
+}
+
+func (vc VisitContext) WithApiKey(resource string) VisitContext {
+	return vc.WithValue(middlewares.CtxKeyApiKey, resource)
 }

--- a/rate/http/visit_context_test.go
+++ b/rate/http/visit_context_test.go
@@ -1,0 +1,56 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Conflux-Chain/go-conflux-util/http/middlewares"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	TestResource = "rpc-all"
+	TestRealIp   = "127.0.0.1"
+	TestApiKey   = "abcde123456"
+	TestDummyKey = "dummy"
+
+	NewTestResource = "another-rpc-all"
+	NewTestRealIp   = "192.168.0.1"
+	NewTestApiKey   = "ABCDE123456"
+)
+
+func TestVisitContext(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, middlewares.CtxKeyRealIP, TestRealIp)
+	ctx = context.WithValue(ctx, middlewares.CtxKeyApiKey, TestApiKey)
+
+	vc := NewVisitContext(ctx, TestResource)
+
+	resrc, ok := vc.Resource()
+	assert.True(t, ok)
+	assert.Equal(t, resrc, TestResource)
+
+	ip, ok := vc.Ip()
+	assert.True(t, ok)
+	assert.Equal(t, ip, TestRealIp)
+
+	apiKey, ok := vc.ApiKey()
+	assert.True(t, ok)
+	assert.Equal(t, apiKey, TestApiKey)
+
+	dummyV, ok := vc.Value(TestDummyKey).(string)
+	assert.False(t, ok)
+	assert.Empty(t, dummyV)
+
+	vc = vc.WithResource(NewTestResource)
+	resrc, _ = vc.Resource()
+	assert.Equal(t, resrc, NewTestResource)
+
+	vc = vc.WithIp(NewTestRealIp)
+	resrc, _ = vc.Ip()
+	assert.Equal(t, resrc, NewTestRealIp)
+
+	vc = vc.WithApiKey(NewTestApiKey)
+	resrc, _ = vc.ApiKey()
+	assert.Equal(t, resrc, NewTestApiKey)
+}

--- a/rate/limiter.go
+++ b/rate/limiter.go
@@ -13,3 +13,42 @@ type Limiter interface {
 	// Generally, it is used for garbage collection.
 	Expired() bool
 }
+
+// ChainedLimiter rate limiters with resposibility chain
+type ChainedLimiter struct {
+	limiters []Limiter
+}
+
+func NewChainedLimiter(limiters ...Limiter) *ChainedLimiter {
+	return &ChainedLimiter{limiters: limiters}
+}
+
+// implements `rate.Limiter` interface
+
+func (cl *ChainedLimiter) Limit() error {
+	return cl.LimitN(1)
+}
+
+func (cl *ChainedLimiter) LimitN(n int) error {
+	return cl.LimitAt(time.Now(), n)
+}
+
+func (cl *ChainedLimiter) LimitAt(now time.Time, n int) error {
+	for i := range cl.limiters {
+		if err := cl.limiters[i].LimitAt(now, n); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (cl *ChainedLimiter) Expired() bool {
+	for i := range cl.limiters {
+		if cl.limiters[i].Expired() {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
1. make `VisitContext` more customable by extending `context.Context`
2. skip rate limiting if empty group or key generated;
3. add responsibility-chained limiter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/go-conflux-util/14)
<!-- Reviewable:end -->
