### PR TITLE
Pass `resource` as context on rate limit `group` and`key` generation

### DIFF
--- a/rate/errors.go
+++ b/rate/errors.go
@@ -11,5 +11,7 @@ func errMaxExceeded(max int) error {
 }
 
 func errRateLimited(max int, waitTime time.Duration) error {
-	return errors.Errorf("Too many requests (> %v), try again after %v", max, waitTime)
+	return errors.Errorf(
+		"Too many requests (> %v), try again after %v", max, waitTime.Round(time.Millisecond),
+	)
 }

--- a/rate/http/registry.go
+++ b/rate/http/registry.go
@@ -11,7 +11,7 @@ import (
 
 type LimiterFactory interface {
 	// GetGroupAndKey generates group and key from context
-	GetGroupAndKey(ctx context.Context) (group, key string, err error)
+	GetGroupAndKey(ctx context.Context, resource string) (group, key string, err error)
 	// Create creates limiter by resource and group
 	Create(ctx context.Context, resource, group string) (rate.Limiter, error)
 }
@@ -57,7 +57,7 @@ func (r *Registry) getLimiters(resource, group string) map[string]rate.Limiter {
 // Limit limits request rate according to HTTP request context.
 // Note, it requires to hook IP/API key middlewares for HTTP server.
 func (r *Registry) Limit(ctx context.Context, resource string) error {
-	group, key, err := r.factory.GetGroupAndKey(ctx)
+	group, key, err := r.factory.GetGroupAndKey(ctx, resource)
 	if err != nil {
 		return errors.WithMessage(err, "Failed to get group and key from visit context")
 	}


### PR DESCRIPTION
also round wait time unit to millisecond for rate limit error

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/go-conflux-util/16)
<!-- Reviewable:end -->
