### PR TITLE
Add file logrus hook with rotation support

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,9 +1,11 @@
-# Log Configurations
+# # Log Configurations
 # log:
 #   level: info
 #   forceColor: false
 #   disableColor: false
-#   alertHook: # Alert hooking settings
+#   reportCaller: false
+#   # Alert hooking settings
+#   alertHook:
 #     # Hooked logrus level for alert notification
 #     level: warn
 #     # Default notification channels
@@ -12,6 +14,37 @@
 #     SendTimeout: 3s
 
 #     # Async worker options for sending alert
+#     async:
+#       # The number of worker goroutines (Set to 0 to disable async mode).
+#       numWorkers: 0
+#       # The maximum number of queued jobs.
+#       queueSize: 60
+#       # Maximum timeout allowed to gracefully stop.
+#       StopTimeout: 5s
+
+#   # File Hooking Configuration
+#   fileHook:
+#     # Groups define logging configurations for different log levels and outputs.
+#     # Each group is identified by a unique, case-insensitive key.
+#     groups:
+#       # Default log group configuration
+#       default:
+#         # Enabled log levels: trace, debug, info, warn, error
+#         levels: []
+#         # Log file path
+#         location: ${your_log_path}
+#         # File rotation settings
+#         rotation:
+#           # Maximum file size (in MB) before rotation
+#           maxSize: 100
+#           # Number of backup files to retain (0 to retain all)
+#           maxBackups: 0
+#           # Maximum age (in days) before log files are deleted
+#           maxAge: 30
+#           # Enable compression for rotated log files
+#           compress: true
+
+#     # Async worker options for logging to file
 #     async:
 #       # The number of worker goroutines (Set to 0 to disable async mode).
 #       numWorkers: 0

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,4 @@
-# # Log Configurations
+# Log Configurations
 # log:
 #   level: info
 #   forceColor: false

--- a/go.mod
+++ b/go.mod
@@ -13,12 +13,14 @@ require (
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/pkg/errors v0.9.1
+	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
 	github.com/samber/slog-logrus/v2 v2.5.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.10.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/time v0.5.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gorm.io/driver/mysql v1.1.2
 	gorm.io/gorm v1.21.15
 )

--- a/go.sum
+++ b/go.sum
@@ -604,6 +604,8 @@ github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/retailnext/hllpp v1.0.1-0.20180308014038-101a6d2f8b52/go.mod h1:RDpi1RftBQPUCDRw6SmxeaREsAaRKnOclghuzp/WRzc=
+github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 h1:mZHayPoR0lNmnHyvtYjDeq0zlVHn9K/ZXoy17ylucdo=
+github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5/go.mod h1:GEXHk5HgEKCvEIIrSpFI3ozzG5xOKA2DVlEX/gGnewM=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=

--- a/log/hook/alert.go
+++ b/log/hook/alert.go
@@ -1,0 +1,126 @@
+package hook
+
+import (
+	"context"
+	stderr "errors"
+	"time"
+
+	"github.com/Conflux-Chain/go-conflux-util/alert"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// logrus entry field configured for alert channels
+	chLogEntryField = "@channel"
+
+	// alert message title
+	alertMsgTitle = "logrus alert notification"
+)
+
+type AlertConfig struct {
+	// Level is the minimum logrus level at which alerts will be triggered.
+	Level string `default:"warn"`
+
+	// Channels lists the default alert notification channels to use.
+	Channels []string
+
+	// Maximum request timeout allowed to send alert.
+	SendTimeout time.Duration `default:"3s"`
+
+	// Async configures the behavior of the asynchronous worker for handling log alerts.
+	Async AsyncOption
+}
+
+// AlertHook logrus hooks to send specified level logs as text message for alerting.
+type AlertHook struct {
+	levels          []logrus.Level
+	defaultChannels []alert.Channel
+	sendTimeout     time.Duration
+}
+
+// NewAlertHook constructor to new AlertHook instance.
+func NewAlertHook(lvls []logrus.Level, chs []alert.Channel, timeout time.Duration) *AlertHook {
+	return &AlertHook{levels: lvls, defaultChannels: chs, sendTimeout: timeout}
+}
+
+// implements `logrus.Hook` interface methods.
+func (hook *AlertHook) Levels() []logrus.Level {
+	return hook.levels
+}
+
+func (hook *AlertHook) Fire(logEntry *logrus.Entry) (err error) {
+	notifyChans, err := hook.getAlertChannels(logEntry)
+	if err != nil || len(notifyChans) == 0 {
+		return err
+	}
+
+	note := &alert.Notification{
+		Title: alertMsgTitle, Content: logEntry,
+		Severity: hook.adaptSeverity(logEntry.Level),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), hook.sendTimeout)
+	defer cancel()
+
+	for _, ch := range notifyChans {
+		err = stderr.Join(ch.Send(ctx, note))
+	}
+
+	return errors.WithMessage(err, "failed to notify channel message")
+}
+
+func (hook *AlertHook) getAlertChannels(logEntry *logrus.Entry) (chs []alert.Channel, err error) {
+	v, ok := logEntry.Data[chLogEntryField]
+	if !ok { // notify channel not configured, use default
+		return hook.defaultChannels, nil
+	}
+
+	var chns []string
+	switch chv := v.(type) {
+	case string:
+		chns = append(chns, chv)
+	case []string:
+		chms := make(map[string]struct{})
+		for _, chn := range chv {
+			if _, ok := chms[chn]; !ok { // dedupe
+				chms[chn] = struct{}{}
+				chns = append(chns, chn)
+			}
+		}
+	case alert.Channel:
+		chs = append(chs, chv)
+		return
+	case []alert.Channel:
+		chs = append(chs, chv...)
+		return
+	default:
+		return nil, errors.New("invalid log entry configured for alert channel")
+	}
+
+	// parse notify channel from channel name
+	for _, chn := range chns {
+		ch, ok := alert.DefaultManager().Channel(chn)
+		if !ok {
+			return nil, alert.ErrChannelNotFound(chn)
+		}
+
+		chs = append(chs, ch)
+	}
+
+	return chs, nil
+}
+
+// adaptSeverity adapts logrus log level to notification severity level.
+func (hook *AlertHook) adaptSeverity(lvl logrus.Level) alert.Severity {
+	switch lvl {
+	case logrus.PanicLevel, logrus.FatalLevel:
+		return alert.SeverityCritical
+	case logrus.ErrorLevel:
+		return alert.SeverityHigh
+	case logrus.WarnLevel:
+		return alert.SeverityMedium
+	default:
+		return alert.SeverityLow
+	}
+}

--- a/log/hook/file.go
+++ b/log/hook/file.go
@@ -1,0 +1,77 @@
+package hook
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rifflock/lfshook"
+	"github.com/sirupsen/logrus"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+type FileConfig struct {
+	// Groups defines the log groups and their associated logging file configuration.
+	Groups map[string]FileGroup
+
+	// Async configures the behavior of the asynchronous worker for handling log alerts.
+	Async AsyncOption
+}
+
+type FileGroup struct {
+	Levels   []string       // Log levels included in this group
+	Location string         // File path for the log group
+	Rotation RotationConfig // Log rotation settings
+}
+
+// RotationConfig defines the rotation settings for log files.
+type RotationConfig struct {
+	MaxSize    int  `default:"100"` // Maximum size of the log file in MB before rotation
+	MaxBackups int  // Maximum number of backup files to retain (0 to keep all)
+	MaxAge     int  `default:"30"`   // Maximum age of log files before deletion (e.g., 30 days)
+	Compress   bool `default:"true"` // Whether to compress rotated log files
+}
+
+func newLumberjackLogger(grpConf FileGroup) *lumberjack.Logger {
+	return &lumberjack.Logger{
+		Filename:   grpConf.Location,
+		MaxSize:    grpConf.Rotation.MaxSize,
+		MaxBackups: grpConf.Rotation.MaxBackups,
+		MaxAge:     grpConf.Rotation.MaxAge,
+		Compress:   grpConf.Rotation.Compress,
+	}
+}
+
+// NewFileHook constructor to new FileHook instance.
+func NewFileHook(conf FileConfig, formatter logrus.Formatter) (*lfshook.LfsHook, error) {
+	var defaultLogger *lumberjack.Logger
+	writerMap := make(lfshook.WriterMap)
+
+	for grp, grpConf := range conf.Groups {
+		if strings.EqualFold(grp, "default") {
+			defaultLogger = newLumberjackLogger(grpConf)
+			continue
+		}
+		if len(grpConf.Levels) == 0 {
+			return nil, errors.Errorf("no log levels defined for group %s", grp)
+		}
+
+		logger := newLumberjackLogger(grpConf)
+		for _, l := range grpConf.Levels {
+			level, err := logrus.ParseLevel(l)
+			if err != nil {
+				return nil, errors.WithMessage(err, "failed to parse log level")
+			}
+			if _, ok := writerMap[level]; ok {
+				return nil, errors.Errorf("duplicate log level %s in group %s", l, grp)
+			}
+			writerMap[level] = logger
+		}
+	}
+
+	hook := lfshook.NewHook(writerMap, formatter)
+	if defaultLogger != nil {
+		hook.SetDefaultWriter(defaultLogger)
+	}
+	return hook, nil
+}

--- a/log/hook/file.go
+++ b/log/hook/file.go
@@ -14,7 +14,7 @@ type FileConfig struct {
 	// Groups defines the log groups and their associated logging file configuration.
 	Groups map[string]FileGroup
 
-	// Async configures the behavior of the asynchronous worker for handling log alerts.
+	// Async configures the behavior of the asynchronous worker for file logging.
 	Async AsyncOption
 }
 

--- a/log/hook/hook.go
+++ b/log/hook/hook.go
@@ -2,42 +2,18 @@ package hook
 
 import (
 	"context"
-	stderr "errors"
 	"sync"
-	"time"
 
 	"github.com/Conflux-Chain/go-conflux-util/alert"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	// logrus entry field configured for alert channels
-	chLogEntryField = "@channel"
-
-	// alert message title
-	alertMsgTitle = "logrus alert notification"
-)
-
-type Config struct {
-	// Level is the minimum logrus level at which alerts will be triggered.
-	Level string `default:"warn"`
-
-	// Channels lists the default alert notification channels to use.
-	Channels []string
-
-	// Maximum request timeout allowed to send alert.
-	SendTimeout time.Duration `default:"3s"`
-
-	// Async configures the behavior of the asynchronous worker for handling log alerts.
-	Async AsyncOption
-}
-
 // AddAlertHook attaches a custom logrus Hook for generating alert notifications
 // based on configured levels and channels.
 // It supports both synchronous and asynchronous operation modes, with optional
 // graceful shutdown integration.
-func AddAlertHook(ctx context.Context, wg *sync.WaitGroup, conf Config) error {
+func AddAlertHook(ctx context.Context, wg *sync.WaitGroup, conf AlertConfig) error {
 	if len(conf.Channels) == 0 {
 		// No channels configured, so no hook needs to be added.
 		return nil
@@ -78,6 +54,32 @@ func AddAlertHook(ctx context.Context, wg *sync.WaitGroup, conf Config) error {
 	return nil
 }
 
+// AddFileHook attaches a custom logrus Hook for writing to log files based on configured levels and rotation settings.
+// Supports synchronous and asynchronous modes with optional graceful shutdown integration.
+func AddFileHook(ctx context.Context, wg *sync.WaitGroup, formatter logrus.Formatter, conf FileConfig) error {
+	// Return early if no groups are configured.
+	if len(conf.Groups) == 0 {
+		return nil
+	}
+
+	// Create a file hook using the provided configuration and formatter.
+	var fileHook logrus.Hook
+	fileHook, err := NewFileHook(conf, formatter)
+	if err != nil {
+		return errors.Wrap(err, "failed to create file hook")
+	}
+
+	// Wrap the hook with asynchronous processing if configured.
+	if conf.Async.NumWorkers > 0 {
+		fileHook = wrapAsyncHook(ctx, wg, fileHook, conf.Async)
+	}
+
+	// Attach the hook to logrus.
+	logrus.AddHook(fileHook)
+
+	return nil
+}
+
 // wrapAsyncHook wraps the given hook with asynchronous processing, optionally integrating
 // graceful shutdown support if a context and wait group are provided.
 func wrapAsyncHook(
@@ -87,97 +89,4 @@ func wrapAsyncHook(
 	}
 
 	return NewAsyncHook(hook, opt)
-}
-
-// AlertHook logrus hooks to send specified level logs as text message for alerting.
-type AlertHook struct {
-	levels          []logrus.Level
-	defaultChannels []alert.Channel
-	sendTimeout     time.Duration
-}
-
-// NewAlertHook constructor to new AlertHook instance.
-func NewAlertHook(lvls []logrus.Level, chs []alert.Channel, timeout time.Duration) *AlertHook {
-	return &AlertHook{levels: lvls, defaultChannels: chs, sendTimeout: timeout}
-}
-
-// implements `logrus.Hook` interface methods.
-func (hook *AlertHook) Levels() []logrus.Level {
-	return hook.levels
-}
-
-func (hook *AlertHook) Fire(logEntry *logrus.Entry) (err error) {
-	notifyChans, err := hook.getAlertChannels(logEntry)
-	if err != nil || len(notifyChans) == 0 {
-		return err
-	}
-
-	note := &alert.Notification{
-		Title: alertMsgTitle, Content: logEntry,
-		Severity: hook.adaptSeverity(logEntry.Level),
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), hook.sendTimeout)
-	defer cancel()
-
-	for _, ch := range notifyChans {
-		err = stderr.Join(ch.Send(ctx, note))
-	}
-
-	return errors.WithMessage(err, "failed to notify channel message")
-}
-
-func (hook *AlertHook) getAlertChannels(logEntry *logrus.Entry) (chs []alert.Channel, err error) {
-	v, ok := logEntry.Data[chLogEntryField]
-	if !ok { // notify channel not configured, use default
-		return hook.defaultChannels, nil
-	}
-
-	var chns []string
-	switch chv := v.(type) {
-	case string:
-		chns = append(chns, chv)
-	case []string:
-		chms := make(map[string]struct{})
-		for _, chn := range chv {
-			if _, ok := chms[chn]; !ok { // dedupe
-				chms[chn] = struct{}{}
-				chns = append(chns, chn)
-			}
-		}
-	case alert.Channel:
-		chs = append(chs, chv)
-		return
-	case []alert.Channel:
-		chs = append(chs, chv...)
-		return
-	default:
-		return nil, errors.New("invalid log entry configured for alert channel")
-	}
-
-	// parse notify channel from channel name
-	for _, chn := range chns {
-		ch, ok := alert.DefaultManager().Channel(chn)
-		if !ok {
-			return nil, alert.ErrChannelNotFound(chn)
-		}
-
-		chs = append(chs, ch)
-	}
-
-	return chs, nil
-}
-
-// adaptSeverity adapts logrus log level to notification severity level.
-func (hook *AlertHook) adaptSeverity(lvl logrus.Level) alert.Severity {
-	switch lvl {
-	case logrus.PanicLevel, logrus.FatalLevel:
-		return alert.SeverityCritical
-	case logrus.ErrorLevel:
-		return alert.SeverityHigh
-	case logrus.WarnLevel:
-		return alert.SeverityMedium
-	default:
-		return alert.SeverityLow
-	}
 }


### PR DESCRIPTION
- Add `file` logrus hook to logging to different file location groupped by different log levels with rotation support
- Separate `file` and `alert` logrus hook to different files for more clarity

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/go-conflux-util/62)
<!-- Reviewable:end -->
