### PR TITLE
Fix markdown formatter for telegram notification

### DIFF
--- a/alert/formatter.go
+++ b/alert/formatter.go
@@ -192,6 +192,7 @@ type TelegramMarkdownFormatter struct {
 
 func NewTelegramMarkdownFormatter(tags, atUsers []string) (f *TelegramMarkdownFormatter, err error) {
 	funcMap := template.FuncMap{
+		"toString":               toString,
 		"escapeMarkdown":         escapeMarkdown,
 		"formatRFC3339":          formatRFC3339,
 		"truncateStringWithTail": truncateStringWithTail,
@@ -205,6 +206,13 @@ func NewTelegramMarkdownFormatter(tags, atUsers []string) (f *TelegramMarkdownFo
 	}
 
 	return &TelegramMarkdownFormatter{markdownFormatter: mf}, nil
+}
+
+func toString(val interface{}) string {
+	if str, ok := val.(string); ok {
+		return str
+	}
+	return fmt.Sprintf("%v", val)
 }
 
 func escapeMarkdown(v interface{}) string {

--- a/alert/templates.go
+++ b/alert/templates.go
@@ -91,7 +91,7 @@ Reason
 {{.Error | escapeMarkdown}}
 
 {{else}}{{ end }}{{ if .CtxFields }}*Context Fields*:{{ range $Key, $Val := .CtxFields }}
-    *{{$Key | escapeMarkdown}}*: {{$Val | truncateStringWithTail | escapeMarkdown}}{{ end }}{{ end }}
+    *{{$Key | escapeMarkdown}}*: {{$Val | toString | truncateStringWithTail | escapeMarkdown}}{{ end }}{{ end }}
 {{ range mentions }}@{{ . }} {{ end }}
 `,
 	}


### PR DESCRIPTION
- Always convert context field value to string before pipeline operations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/go-conflux-util/64)
<!-- Reviewable:end -->
