### PR TITLE
Should not evict initialized blocks from reorg window before verifyin…

### DIFF
--- a/blockchain/sync/poll/latest_poller.go
+++ b/blockchain/sync/poll/latest_poller.go
@@ -26,17 +26,22 @@ type LatestPoller[T any] struct {
 	health          *health.TimedCounter
 }
 
-func NewLatestPoller[T any](adapter Adapter[T], nextBlockNumber uint64, reorgParams ReorgWindowParams, option ...Option) *LatestPoller[T] {
+func NewLatestPoller[T any](adapter Adapter[T], nextBlockNumber uint64, reorgParams ReorgWindowParams, option ...Option) (*LatestPoller[T], error) {
 	opt := normalizeOpt(option...)
+
+	window, err := NewReorgWindowWithLatestBlocks(reorgParams)
+	if err != nil {
+		return nil, errors.WithMessage(err, "Failed to create reorg window")
+	}
 
 	return &LatestPoller[T]{
 		option:          opt,
 		adapter:         adapter,
 		nextBlockNumber: nextBlockNumber,
 		dataCh:          make(chan Revertable[T], opt.BufferSize),
-		window:          NewReorgWindowWithLatestBlocks(reorgParams),
+		window:          window,
 		health:          health.NewTimedCounter(opt.Health),
-	}
+	}, nil
 }
 
 // DataCh returns a read-only channel to consume data. The channel will not be closed
@@ -122,21 +127,17 @@ func (poller *LatestPoller[T]) pollOnce(ctx context.Context) (data T, ok bool, r
 	// detect reorg
 	blockHash := poller.adapter.GetBlockHash(data)
 	parentBlockHash := poller.adapter.GetParentBlockHash(data)
-	appended, popped := poller.window.Push(poller.nextBlockNumber, blockHash, parentBlockHash)
-	if appended {
-		return data, true, false, nil
+	appended, popped, err := poller.window.Push(poller.nextBlockNumber, blockHash, parentBlockHash)
+
+	// should never happen
+	if err != nil {
+		log.WithModule(ModuleName).WithError(err).WithFields(logrus.Fields{
+			"block":  poller.nextBlockNumber,
+			"hash":   blockHash,
+			"parent": parentBlockHash,
+			"window": poller.window,
+		}).Fatal("Block not in sequence or finalized block reverted")
 	}
 
-	if popped {
-		return data, false, true, nil
-	}
-
-	log.WithModule(ModuleName).WithFields(logrus.Fields{
-		"block":  poller.nextBlockNumber,
-		"hash":   blockHash,
-		"parent": parentBlockHash,
-		"window": poller.window,
-	}).Fatal("Block not in sequence")
-
-	return data, false, false, nil
+	return data, appended, popped, nil
 }

--- a/blockchain/sync/poll/reorg_window.go
+++ b/blockchain/sync/poll/reorg_window.go
@@ -9,82 +9,117 @@ type ReorgWindowParams struct {
 }
 
 // ReorgWindow is used to detect chain reorg.
+//
+// Basically, the reorg window maintains the recent blocks and the latest finalized block.
+//
+// Note, the reorg window do not require a capacity. Because, the data size of block number
+// and hash are very small. Besides, there are a few blocks between the finalized block and latest block.
 type ReorgWindow struct {
-	// no capacity, since max(latest_finalized, latest_checkpoint) is small enough
-	blockNumber2Hashes map[uint64]string
-	earliest, latest   uint64
+	blockNumber2Hashes map[uint64]string // recent blocks in sequence
+	finalized          uint64            // the finalized block number, which will not be reverted
+	latest             uint64            // the latest block number, which may be reverted
+	verified           bool              // whether verified by on-chain data
 }
 
+// NewReorgWindow creates an empty reorg window. Generally, it is used to sync from the genesis block.
 func NewReorgWindow() *ReorgWindow {
 	return &ReorgWindow{
 		blockNumber2Hashes: make(map[uint64]string),
 	}
 }
 
-// NewReorgWindowWithLatestBlocks initializes with given latest blocks and the last finalized block number.
+// NewReorgWindowWithLatestBlocks creates a reorg window with given recent blocks and the last finalized block number.
 //
 // When service restarted, user should load recent blocks and the last finalized block from database,
 // and initialize the reorg window so as to correctly handle chain reorg during the service down time.
-func NewReorgWindowWithLatestBlocks(params ReorgWindowParams) *ReorgWindow {
+func NewReorgWindowWithLatestBlocks(params ReorgWindowParams) (*ReorgWindow, error) {
 	window := NewReorgWindow()
+
 	if len(params.FinalizedBlockHash) == 0 {
-		return window
+		return window, nil
 	}
 
-	window.earliest = params.FinalizedBlockNumber
+	// set the finalized block
+	window.finalized = params.FinalizedBlockNumber
 	window.latest = params.FinalizedBlockNumber
 	window.blockNumber2Hashes[params.FinalizedBlockNumber] = params.FinalizedBlockHash
 
-	for {
-		hash, ok := params.LatestBlocks[window.latest+1]
+	// continuous blocks required
+	for i, numBlocks := 0, len(params.LatestBlocks); i < numBlocks; i++ {
+		expectedBlockNumber := params.FinalizedBlockNumber + 1 + uint64(i)
+
+		hash, ok := params.LatestBlocks[expectedBlockNumber]
 		if !ok {
-			break
+			return nil, fmt.Errorf("Block %v missed", expectedBlockNumber)
 		}
 
-		window.latest++
-		window.blockNumber2Hashes[window.latest] = hash
+		window.blockNumber2Hashes[expectedBlockNumber] = hash
+		window.latest = expectedBlockNumber
 	}
 
-	return window
+	return window, nil
 }
 
-func (window *ReorgWindow) Push(blockNumber uint64, blockHash, parentBlockHash string) (appended, popped bool) {
-	// window is empty
+// Push pushes the latest block into reorg window.
+func (window *ReorgWindow) Push(blockNumber uint64, blockHash, parentBlockHash string) (appended, popped bool, err error) {
+	// window is empty, e.g. sync from genesis block
 	if len(window.blockNumber2Hashes) == 0 {
-		window.earliest = blockNumber
+		window.finalized = blockNumber
 		window.latest = blockNumber
 		window.blockNumber2Hashes[blockNumber] = blockHash
-		return true, false
+		window.verified = true
+		return true, false, nil
 	}
 
 	// not in sequence
 	if window.latest+1 != blockNumber {
-		return false, false
+		return false, false, fmt.Errorf("Block not in sequence, latest = %v, new = %v", window.latest, blockNumber)
 	}
 
-	// appended
+	// appended if parent block hash matches
 	if window.blockNumber2Hashes[window.latest] == parentBlockHash {
 		window.blockNumber2Hashes[blockNumber] = blockHash
 		window.latest = blockNumber
-		return true, false
+		window.verified = true
+		return true, false, nil
 	}
 
-	// parent block hash mismatch, reorg detected
+	// finalized block should never be reverted
+	if window.finalized == window.latest {
+		return false, false, fmt.Errorf("Finalized block %v should not be reverted", window.finalized)
+	}
+
+	// reorg detected, pop the latest block from reorg window
 	delete(window.blockNumber2Hashes, window.latest)
 	window.latest--
 
-	return false, true
+	return false, true, nil
 }
 
-func (window *ReorgWindow) Evict(blockNumber uint64) {
+// Evict evicts finalized blocks from reorg window.
+func (window *ReorgWindow) Evict(finalizedBlockNumber uint64) (evicted int) {
 	if len(window.blockNumber2Hashes) == 0 {
 		return
 	}
 
-	for i, end := window.earliest, min(blockNumber, window.latest); i <= end; i++ {
-		delete(window.blockNumber2Hashes, i)
-		window.earliest++
+	// When service restarted, the reorg window will be initialized with recent blocks from database.
+	// These blocks may be reverted during service down time, and requires to compare with on-chain blocks.
+	// So, only when new on-chain block successfully pushed into the reorg window, the recent blocks could
+	// be evicted from reorg window.
+	if !window.verified {
+		return
 	}
+
+	// keep at latest one finalized block
+	evictUntil := min(finalizedBlockNumber, window.latest)
+
+	for i := window.finalized; i < evictUntil; i++ {
+		delete(window.blockNumber2Hashes, i)
+		window.finalized++
+		evicted++
+	}
+
+	return
 }
 
 func (window ReorgWindow) String() string {
@@ -92,6 +127,6 @@ func (window ReorgWindow) String() string {
 		return "{ blocks = 0 }"
 	}
 
-	return fmt.Sprintf("{ blocks = %v, earliest = %v, latest = %v }",
-		len(window.blockNumber2Hashes), window.earliest, window.latest)
+	return fmt.Sprintf("{ blocks = %v, finalized = %v, latest = %v, verified = %v }",
+		len(window.blockNumber2Hashes), window.finalized, window.latest, window.verified)
 }

--- a/blockchain/sync/poll/reorg_window_test.go
+++ b/blockchain/sync/poll/reorg_window_test.go
@@ -11,30 +11,36 @@ func TestReorgWindowPush(t *testing.T) {
 	window := NewReorgWindow()
 
 	// push empty
-	pushed, popped := window.Push(5, "Hash - 5", "Hash - 4")
+	pushed, popped, err := window.Push(5, "Hash - 5", "Hash - 4")
+	assert.NoError(t, err)
 	assert.Equal(t, true, pushed)
 	assert.Equal(t, false, popped)
 
 	// push in sequence
-	pushed, popped = window.Push(6, "Hash - 6", "Hash - 5")
+	pushed, popped, err = window.Push(6, "Hash - 6", "Hash - 5")
+	assert.NoError(t, err)
 	assert.Equal(t, true, pushed)
 	assert.Equal(t, false, popped)
 
 	// push not in sequence
-	pushed, popped = window.Push(6, "Hash - 6", "Hash - 5")
-	assert.Equal(t, false, pushed)
-	assert.Equal(t, false, popped)
-	pushed, popped = window.Push(8, "Hash - 8", "Hash - 7")
-	assert.Equal(t, false, pushed)
-	assert.Equal(t, false, popped)
+	_, _, err = window.Push(6, "Hash - 6", "Hash - 5")
+	assert.Error(t, err)
+	_, _, err = window.Push(8, "Hash - 8", "Hash - 7")
+	assert.Error(t, err)
 
 	// push in sequence, but parent hash mismatch
-	pushed, popped = window.Push(7, "Hash - 7", "Hash - 66")
+	pushed, popped, err = window.Push(7, "Hash - 7", "Hash - 66")
+	assert.NoError(t, err)
 	assert.Equal(t, false, pushed)
 	assert.Equal(t, true, popped)
 
-	// push block 6 again due to popped
-	pushed, popped = window.Push(6, "Hash - 66", "Hash - 5")
+	// pop the finalized block 5
+	_, _, err = window.Push(6, "Hash - 66", "Hash - 55")
+	assert.Error(t, err)
+
+	// push block 6 again
+	pushed, popped, err = window.Push(6, "Hash - 66", "Hash - 5")
+	assert.NoError(t, err)
 	assert.Equal(t, true, pushed)
 	assert.Equal(t, false, popped)
 }
@@ -43,28 +49,25 @@ func TestReorgWindowEvict(t *testing.T) {
 	window := NewReorgWindow()
 
 	// evict empty window
-	window.Evict(5)
+	assert.Equal(t, 0, window.Evict(5))
 
 	// push block 1 - 9
-	for i := uint64(1); i < 10; i++ {
-		pushed, popped := window.Push(i, fmt.Sprintf("Hash - %v", i), fmt.Sprintf("Hash - %v", i-1))
+	for i := uint64(1); i <= 9; i++ {
+		pushed, popped, err := window.Push(i, fmt.Sprintf("Hash - %v", i), fmt.Sprintf("Hash - %v", i-1))
+		assert.NoError(t, err)
 		assert.Equal(t, true, pushed)
 		assert.Equal(t, false, popped)
 	}
 
-	// evict block 5
-	window.Evict(5)
-	assert.Equal(t, uint64(6), window.earliest)
-	assert.Equal(t, uint64(9), window.latest)
+	// finalized block == 5, evict block 1 - 4.
+	assert.Equal(t, 4, window.Evict(5))
 
-	// evict block 9
-	window.Evict(9)
-	assert.Equal(t, uint64(10), window.earliest)
-	assert.Equal(t, uint64(9), window.latest)
+	// finalized block is very big, then evit all except the latest block 9
+	assert.Equal(t, 4, window.Evict(100))
 }
 
 func TestReorgWindowWithLatestBlocks(t *testing.T) {
-	window := NewReorgWindowWithLatestBlocks(ReorgWindowParams{
+	window, err := NewReorgWindowWithLatestBlocks(ReorgWindowParams{
 		FinalizedBlockNumber: 5,
 		FinalizedBlockHash:   "Hash - 5",
 		LatestBlocks: map[uint64]string{
@@ -73,11 +76,21 @@ func TestReorgWindowWithLatestBlocks(t *testing.T) {
 			8: "Hash - 8",
 		},
 	})
+	assert.NoError(t, err)
 
-	assert.Equal(t, uint64(5), window.earliest)
-	assert.Equal(t, uint64(8), window.latest)
+	// evict nothing since not verify against on-chain data
+	assert.Equal(t, 0, window.Evict(100))
+	assert.Equal(t, 0, window.Evict(7))
 
-	pushed, popped := window.Push(9, "Hash - 9", "Hash - 8")
+	// push block 9, but reorg happened during service down time
+	pushed, popped, err := window.Push(9, "Hash - 9", "Hash - 88")
+	assert.NoError(t, err)
+	assert.Equal(t, false, pushed)
+	assert.Equal(t, true, popped)
+
+	// push block 8
+	pushed, popped, err = window.Push(8, "Hash - 88", "Hash - 7")
+	assert.NoError(t, err)
 	assert.Equal(t, true, pushed)
 	assert.Equal(t, false, popped)
 }

--- a/blockchain/sync/sync_db.go
+++ b/blockchain/sync/sync_db.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Conflux-Chain/go-conflux-util/blockchain/sync/process"
 	"github.com/Conflux-Chain/go-conflux-util/blockchain/sync/process/db"
 	"github.com/Conflux-Chain/go-conflux-util/channel"
+	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
 
@@ -56,12 +57,18 @@ func StartFinalizedDB[T any](ctx context.Context, wg *sync.WaitGroup, params Par
 	go process.Process(ctx, wg, poller.DataCh(), processor)
 }
 
-func StartLatestDB[T any](ctx context.Context, wg *sync.WaitGroup, params ParamsDB[T], processors ...db.RevertableProcessor[T]) {
-	poller := poll.NewLatestPoller(params.Adapter, params.NextBlockNumber, params.Reorg, params.Poller)
+func StartLatestDB[T any](ctx context.Context, wg *sync.WaitGroup, params ParamsDB[T], processors ...db.RevertableProcessor[T]) error {
+	poller, err := poll.NewLatestPoller(params.Adapter, params.NextBlockNumber, params.Reorg, params.Poller)
+	if err != nil {
+		return errors.WithMessage(err, "Failed to create latest poller")
+	}
+
 	wg.Add(1)
 	go poller.Poll(ctx, wg)
 
 	processor := db.NewRevertableAggregateProcessor(params.Processor, params.DB, processors...)
 	wg.Add(1)
 	go process.Process(ctx, wg, poller.DataCh(), processor)
+
+	return nil
 }


### PR DESCRIPTION
…g with on-chain data

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/go-conflux-util/102)
<!-- Reviewable:end -->
